### PR TITLE
Fix IA link on colophon

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -23,7 +23,7 @@
 			for<br/>
 			<a href="https://www.gutenberg.org/ebooks/35117">Project Gutenberg</a><br/>
 			and on digital scans available at the<br/>
-			<a href="https://archive.org/details/lordtonyswifean01orczgoog/page/n245/mode/2up">Internet Archive</a>.</p>
+			<a href="https://archive.org/details/lordtonyswifean01orczgoog">Internet Archive</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Portrait of a Woman</i>,<br/>
 			a painting completed in 1753 by<br/>


### PR DESCRIPTION
The IA link goes to a specific page instead of the general page scan link.